### PR TITLE
Package the script as a Nix Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1703134684,
+        "narHash": "sha256-SQmng1EnBFLzS7WSRyPM9HgmZP2kLJcPAz+Ug/nug6o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d6863cbcbbb80e71cecfc03356db1cda38919523",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,22 +1,57 @@
 {
   "nodes": {
-    "nixpkgs": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1703134684,
-        "narHash": "sha256-SQmng1EnBFLzS7WSRyPM9HgmZP2kLJcPAz+Ug/nug6o=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d6863cbcbbb80e71cecfc03356db1cda38919523",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1703200657,
+        "narHash": "sha256-MlylIcE4f0nly70R20GQguxn3y1hrpFMdtxKsSLuJso=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "02b3c06b1ce6b2fb2af10d99e5c2e99a7cc6bf94",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,11 @@
+{
+  description = "A very basic flake";
+
+  outputs = { self, nixpkgs }: {
+
+    packages.x86_64-linux.hello = nixpkgs.legacyPackages.x86_64-linux.hello;
+
+    packages.x86_64-linux.default = self.packages.x86_64-linux.hello;
+
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,39 @@
 {
-  description = "A very basic flake";
+  description = "Interactive Tmux wrapper for easier session attachment";
 
-  outputs = { self, nixpkgs }: {
-
-    packages.x86_64-linux.hello = nixpkgs.legacyPackages.x86_64-linux.hello;
-
-    packages.x86_64-linux.default = self.packages.x86_64-linux.hello;
-
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
   };
+
+  outputs = { self, nixpkgs, flake-utils }:
+  flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs { inherit system; };
+    in
+    {
+      packages = rec {
+        tmux-attacher = pkgs.stdenv.mkDerivation rec {
+          name = "tmux-attacher";
+          src = ./.;
+          unpackPhase = "true"; # FIXME what does this mean?
+          buildPhase = ":"; # FIXME what does this mean?
+          installPhase =
+            ''
+              mkdir -p "$out/bin"
+              cp "$src/tmux-attacher" "$out/bin/tmux-attacher"
+              chmod +x "$out/bin/tmux-attacher"
+            '';
+        };
+        default = tmux-attacher;
+      };
+
+      apps = rec {
+        tmux-attacher = flake-utils.lib.mkApp {
+          drv = self.packages.${system}.tmux-attacher;
+        };
+        default = tmux-attacher;
+      };
+    }
+  );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
       packages = rec {
         tmux-attacher = pkgs.stdenv.mkDerivation rec {
           name = "tmux-attacher";
+          runtimeInputs = [ pkgs.gum ];
           src = ./.;
           unpackPhase = "true"; # FIXME what does this mean?
           buildPhase = ":"; # FIXME what does this mean?

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,12 @@
       pkgs = import nixpkgs { inherit system; };
     in
     {
+      devShells = rec {
+        default = pkgs.mkShell {
+          packages = [ pkgs.gum ];
+        };
+      };
+
       packages = rec {
         tmux-attacher = pkgs.stdenv.mkDerivation rec {
           name = "tmux-attacher";

--- a/flake.nix
+++ b/flake.nix
@@ -19,21 +19,16 @@
       };
 
       packages = rec {
-        tmux-attacher = pkgs.stdenv.mkDerivation rec {
-          name = "tmux-attacher";
-          runtimeInputs = [ pkgs.gum ];
-          src = ./.;
-          unpackPhase = "true"; # FIXME what does this mean?
-          buildPhase = ":"; # FIXME what does this mean?
-          installPhase =
-            ''
-              mkdir -p "$out/bin"
-              cp "$src/tmux-attacher" "$out/bin/tmux-attacher"
-              chmod +x "$out/bin/tmux-attacher"
-            '';
-        };
+        # This approach employs a wrapper script that modifies the runtime PATH
+        # passed to `tmux-attacher` before executing it.
+        tmux-attacher = pkgs.writeScriptBin "tmux-attacher" ''
+          export PATH="${pkgs.lib.makeBinPath [ pkgs.gum ]}:$PATH"
+          ${./tmux-attacher}
+        '';
+
         default = tmux-attacher;
       };
+
 
       apps = rec {
         tmux-attacher = flake-utils.lib.mkApp {

--- a/tmux-attacher
+++ b/tmux-attacher
@@ -2,37 +2,6 @@
 set -eu
 
 # ╔════════════════════════════════════════════════════════════════════════╗
-# ║ Logging functions                                                      ║
-# ╚════════════════════════════════════════════════════════════════════════╝
-
-COLOR_ERROR='\033[91m' # Light red.
-COLOR_INFO='\033[94m' # Light blue.
-COLOR_PROMPT='\033[92m' # Light Green.
-COLOR_RESET='\033[0m'
-
-# Prints a message using a specific color. Don't call this function directly on
-# the script.
-log_with_color() {
-    printf "${1}%s${COLOR_RESET}\n" "${2}"
-}
-
-# Prints a message color-coded for information.
-log_info() {
-    log_with_color "${COLOR_INFO}" "${1}"
-}
-
-# Prints a message line color-coded for interactive prompts.
-log_with_prompt_colors() {
-    log_with_color "${COLOR_PROMPT}" "${1}"
-}
-
-# Prints an error message, then exits with error code 1.
-log_fatal() {
-    log_with_color "${COLOR_ERROR}" "Error: ${1}"
-    exit 1
-}
-
-# ╔════════════════════════════════════════════════════════════════════════╗
 # ║ Aux functions                                                          ║
 # ╚════════════════════════════════════════════════════════════════════════╝
 
@@ -41,20 +10,17 @@ has_command() {
     command -v "${1}" >/dev/null 2>&1 
 }
 
-# Fails if the session named after $1 does not exist.
-tmux_session_exists() {
-    tmux has-session -t "${1}" 2>/dev/null
-}
-
 # ╔════════════════════════════════════════════════════════════════════════╗
 # ║ User prompt helpers                                                    ║
 # ╚════════════════════════════════════════════════════════════════════════╝
 
-# Print text to be used in a prompt. Does not include the `read` command.
-print_prompt() {
-    # Prints the text provided in `${1}` with light green color and no newline.
-    printf "${COLOR_PROMPT}%s${COLOR_RESET} " "${1}"
+prompt_user_select_tmux_session() {
+    {
+        echo '[new session]'
+        tmux list-sessions -F '#{session_name}'
+    } | gum choose --select-if-one
 }
+
 
 # ╔════════════════════════════════════════════════════════════════════════╗
 # ║ Script starts here:                                                    ║
@@ -65,19 +31,12 @@ if ! has_command 'gum'; then
     echo "${0} requires 'gum' to provide interactive prompts."
     echo "Install 'gum' and ensure it is available in your PATH"
     exit 1
-else
-    gum log --level debug 'Gum available!'
 fi
 
-# Fail if tmux is not installed correctly.
-if ! has_command "tmux"; then
-    # Disabling SC2016. We don't want to expand $PATH.
-    # shellcheck disable=SC2016
-    log_fatal 'Command tmux not found in $PATH'
-fi
+has_command 'tmux' || gum log --level fatal --structured 'Required program not found in PATH' program 'tmux'
 
-# If any arguments were provided to the script, delegate them to `tmux`, then
-# exit. We only care about extending the functionality with an interactive
+# If any other arguments were provided to the script, delegate them to `tmux`,
+# then exit. We only care about extending the functionality with an interactive
 # prompt in case no arguments were provided.
 if [ "${#}" -ne "0" ]; then
     # Disabling SC2068. In this case, we explicitly want to re-split elements.
@@ -86,67 +45,16 @@ if [ "${#}" -ne "0" ]; then
     exit "${?}" # Resend `tmux` exit status code.
 fi
 
-# Prints a list of active Tmux sessions.
-log_info "Available Tmux sessions:"
-tmux list-sessions
+user_selection="$( prompt_user_select_tmux_session )"
 
-# Ask the user how to open the new tmux client.
-echo
-log_with_prompt_colors "a -- Attach to an existing session."
-log_with_prompt_colors "n -- Attach to a new session."
-log_with_prompt_colors "q -- Cancel."
-print_prompt "What should we do? [a,n,q]:"
-read -r user_selection
-case "${user_selection}" in
+if [ "${user_selection}" = "[new session]" ]; then
+    user_selection="$( gum input --placeholder "New session name" )"
 
-    a)
-        # --------------------------------------------------------------------------
-        # Option "a" -- Attach to an existing session.
-        # --------------------------------------------------------------------------
-        echo
-        print_prompt "Which session should we attach to?"
-        read -r session_name
+    # Create a detached session with the provided name (flag `-d`). We will
+    # attach to it later in the script. This will fail if there is already a
+    # session with the provided name.
+    tmux new-session -s "${user_selection}" -d
+fi
 
-        # Ensure that the provided session exists or exit with error.
-        if ! tmux_session_exists "${session_name}"; then
-            log_fatal "No active session named: ${session_name}"
-        fi
-
-        # Attach to the chosen session.
-        tmux attach -t "${session_name}"
-        exit "${?}"
-
-        ;;
-
-    n)
-        # --------------------------------------------------------------------------
-        # Option "n" -- Attach to a new named session.
-        # --------------------------------------------------------------------------
-        echo
-        print_prompt "How should we name the new session?"
-        read -r session_name
-
-        # Ensure that the provided session name is not already taken.
-        if tmux_session_exists "${session_name}"; then
-            log_fatal "Session named '${session_name}' exists."
-        fi
-
-        # Attach to a new session with the chosen name.
-        tmux new-session -s "${session_name}"
-        exit "${?}"
-        ;;
-
-    q)
-        # --------------------------------------------------------------------------
-        # Option "q" -- Gracefully quit. 
-        # --------------------------------------------------------------------------
-        exit 0
-        ;;
-
-    *)
-        # --------------------------------------------------------------------------
-        # Fallback case -- Bad option.
-        # --------------------------------------------------------------------------
-        log_fatal "Invalid option '${user_selection}'"
-        ;;
-esac
+gum log --level debug --structured 'Attaching session' session "${user_selection}"
+tmux attach -t "${user_selection}"

--- a/tmux-attacher
+++ b/tmux-attacher
@@ -60,6 +60,15 @@ print_prompt() {
 # ║ Script starts here:                                                    ║
 # ╚════════════════════════════════════════════════════════════════════════╝
 
+if ! has_command 'gum'; then
+    echo 'FATAL:'
+    echo "${0} requires 'gum' to provide interactive prompts."
+    echo "Install 'gum' and ensure it is available in your PATH"
+    exit 1
+else
+    gum log --level debug 'Gum available!'
+fi
+
 # Fail if tmux is not installed correctly.
 if ! has_command "tmux"; then
     # Disabling SC2016. We don't want to expand $PATH.


### PR DESCRIPTION
closes #6

# Motivation

This script is simple enough that it only depends on Tmux, making it a good  project to learn how to write a Nix Flake.

Also, I wrote the user interface that way because I did not want to bother including any extra dependency, but I think that that it would benefit from using [gum](https://github.com/charmbracelet/gum) both in terms of UX and simplicity of implementation.

## Goals

- [x] Provide a flake that installs `tmux-attacher` and adds it to the `$PATH`
- [x] Bundle `gum` making it available for `tmux-attacher` while keeping it out of the user's runtime PATH.

## Notes

- This PR includes changes to the script, refactoring it to use `gum` for it's user interface. This was done in order to test the gum dependency.
- I did not address adding tmux as a dependency due to reasons mentioned in #7
